### PR TITLE
Remove unused fs dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.7",
-        "fs": "^0.0.1-security",
         "jwt-decode": "^4.0.0",
         "rxjs": "^7.8.1",
         "web3": "^4.6.0"
@@ -3425,11 +3424,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "axios": "^1.6.7",
-    "fs": "^0.0.1-security",
     "jwt-decode": "^4.0.0",
     "rxjs": "^7.8.1",
     "web3": "^4.6.0"


### PR DESCRIPTION
Remove `fs@0.0.1-security` from `dependencies`.  The package was never imported anywhere in the codebase.

The `fs` npm package is a **security placeholder** published by npm to prevent typosquatting on the built-in module name. It contains no code and provides no functionality.  Beyond being dead weight, it actively breaks installs behind security-scanning registries (e.g. `npm.flatt.tech`), which block it as a suspicious package.